### PR TITLE
fix docker build errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,8 @@ WORKDIR /code
 #RUN pip install --no-cache-dir -r /code/requirements.txt
 
 COPY setup.py /code/setup.py
+COPY README.md /code/README.md
+COPY src /code/src
 
 RUN pip install --no-cache-dir '.[all]'
 


### PR DESCRIPTION
When trying to do a `docker build` I was getting 

1. `FileNotFoundError: [Errno 2] No such file or directory: 'README.md'` 
2. and later `error: error in 'egg_base' option: 'src' does not exist or is not a directory` 

Both were not copied to the working directory. This little PR copies them over.